### PR TITLE
add mechanism to configure and perform a scrolling text

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,32 @@ for {
 	}
 }
 ~~~
+
+## Demo: Write a scrolling text
+
+A simple program to write text on the launchpad
+
+~~~ go
+pad, err := launchpad.Open()
+if err != nil {
+    log.Fatal(err)
+}
+defer pad.Close()
+
+pad.Clear()
+
+// Send Text-Loop
+pad.Text(3, 0).Add(7, "Hello World!").Perform()
+
+ch := pad.Listen()
+for {
+    hit := <-ch
+
+    if hit.IsScrollTextEndMarker() {
+        log.Printf("Scrolling text is ended now.")
+    }
+}
+~~~
     
 ## License
     Copyright 2013 Google Inc. All Rights Reserved.

--- a/cmd/helloworld_text/main.go
+++ b/cmd/helloworld_text/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"log"
+
+	"github.com/rakyll/launchpad"
+)
+
+func main() {
+	pad, err := launchpad.Open()
+	if err != nil {
+		log.Fatalf("error while openning connection to launchpad: %v", err)
+	}
+	defer pad.Close()
+
+	pad.Clear()
+
+	// Send Text-Loop
+	pad.Text(3, 0).
+		Add(7, "Hello ").
+		Add(1, "World!").
+		Perform()
+
+	ch := pad.Listen()
+	for {
+		hit := <-ch
+
+		if hit.IsScrollTextEndMarker() {
+			log.Printf("Scrolling text is ended now.")
+		}
+	}
+}

--- a/launchpad.go
+++ b/launchpad.go
@@ -35,6 +35,13 @@ type Hit struct {
 	Y int
 }
 
+// IsScrollTextEndMarker checks if this hit is an meta event which tells you,
+// that the scrolling text has been finished. On looping scrolling text you
+// will get such an event every time a loop iteration ends!
+func (h Hit) IsScrollTextEndMarker() bool {
+	return h.X == -104 && h.Y == 8
+}
+
 // Open opens a connection Launchpad and initializes an input and output
 // stream to the currently connected device. If there are no
 // devices are connected, it returns an error.

--- a/scrolling_text.go
+++ b/scrolling_text.go
@@ -1,0 +1,59 @@
+package launchpad
+
+import "github.com/rakyll/portmidi"
+
+// ScrollingTextBuilder is used to build and display an scrolling text on the Launchpad.
+type ScrollingTextBuilder struct {
+	seq          []byte
+	outputStream *portmidi.Stream
+}
+
+// Text will return a scrolling text builder whether you can build and
+// perform an text with the given color which will be scrolled on the launchpad.
+func (l *Launchpad) Text(g int, r int) *ScrollingTextBuilder {
+	return l.text(g, r, false)
+}
+
+// TextLoop will return a scrolling text builder whether you can build and
+// perform an text with the given color which will be scrolled endless on the launchpad.
+// If you want to stop an text loop you have to build and execute an empty textLoop!
+func (l *Launchpad) TextLoop(g int, r int) *ScrollingTextBuilder {
+	return l.text(g, r, true)
+}
+
+func (l *Launchpad) text(g int, r int, loop bool) *ScrollingTextBuilder {
+	color := byte(16*g + r + 8 + 4)
+	if loop {
+		color += 64
+	}
+
+	return &ScrollingTextBuilder{
+		seq:          []byte{0xF0, 0x00, 0x20, 0x29, 0x09, color},
+		outputStream: l.outputStream,
+	}
+}
+
+// Add adds a text snipped with a given speed to the builder.
+// The speed can be a value from 1-7. The text must be ASCII
+// characters! Otherwise the result could be weired.
+func (s *ScrollingTextBuilder) Add(speed byte, text string) *ScrollingTextBuilder {
+	if speed > 7 {
+		speed = 7
+	} else if speed < 1 {
+		speed = 1
+	}
+
+	s.seq = append(s.seq, speed)
+	s.seq = append(s.seq, []byte(text)...)
+
+	return s
+}
+
+// Perform sends the pre-built scrolling text to the launchpad.
+func (s *ScrollingTextBuilder) Perform() error {
+	s.seq = append(s.seq, 0xF7)
+
+	// the syntax of the scrolling text message:
+	// F0 00 20 29 09 <colour> <text inclusive speed ...> F7
+	return s.outputStream.WriteSysExBytes(portmidi.Time(), s.seq)
+}


### PR DESCRIPTION
In this pull request I made sure to be backward compatible. It adds functions that allow to display scrolling text on the launchpad.  The Launchpad S offers this functionality natively (see [an PDF-Documentation which i found](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwj2tOiHv-bqAhWECOwKHYxhBDgQFjAAegQIARAB&url=https%3A%2F%2Fwww.bhphotovideo.com%2Flit_files%2F88417.pdf&usg=AOvVaw3ZHVzOJJ2zXbSv6YvTin26)). Since the README says that only the Launchpad S is currently supported, I did not put this functionality into an extra sub-package.